### PR TITLE
Update ctx.guild.icon_url to ctx.guild.icon.url for Compatibility with discord.py v2.0

### DIFF
--- a/lastfm/recent.py
+++ b/lastfm/recent.py
@@ -108,7 +108,7 @@ class RecentMixin(MixinMeta):
         content = discord.Embed(color=await ctx.embed_color())
         content.set_author(
             name=f"What has {ctx.guild.name} been listening to?",
-            icon_url=ctx.guild.icon_url,
+            icon_url = ctx.guild.icon.url if ctx.guild.icon else None,
         )
         content.set_footer(
             text=f"{total_listening} / {total_linked} Members are listening to music right now"


### PR DESCRIPTION
This pull request updates the attribute ctx.guild.icon_url to ctx.guild.icon.url in recent.py to fix an AttributeError. This change ensures compatibility with discord.py version 2.0, which introduced new attribute naming conventions for accessing guild icons.